### PR TITLE
fix: replace '@textury/arkb' npm package with 'arkb'

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ To deploy on IPFS, the CLI uses [ipfs-deploy](https://github.com/ipfs-shipyard/i
 
 ## Arweave
 
-To deploy on Arweave, the CLI uses [@textury/arkb](https://github.com/textury/arkb).
+To deploy on Arweave, the CLI uses [arkb](https://github.com/textury/arkb).
 
 ## Solana Name Service
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -74,7 +74,7 @@ export const deployIpfs = (path: string) => {
 };
 
 export const deployArweave = (path: string, wallet: string) => {
-  const cmd = `npx @textury/arkb deploy ${path} --wallet ${wallet} --auto-confirm`;
+  const cmd = `npx arkb deploy ${path} --wallet ${wallet} --auto-confirm`;
   const hash = execSync(cmd).toString();
   return hash.split("https://arweave.net/")[1];
 };

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -10,7 +10,6 @@ import fs from "fs";
 import { Keypair } from "@solana/web3.js";
 import ora from "ora";
 import { execSync } from "child_process";
-import { postIpfs2Arweave } from "./utils";
 
 clear();
 


### PR DESCRIPTION
- changes code and readme to reference https://www.npmjs.com/package/arkb instead of https://www.npmjs.com/package/@textury/arkb as the scoped package doesn't exist now.

- removes an import of a function that doesn't exist (utils.postIpfs2Arweave)